### PR TITLE
ウィンドウに表示されているもののみをいいねする

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "cSpell.words": ["aamw", "fadein", "webextensions"],
+  "cSpell.words": ["aamw", "aatk", "abcm", "fadein", "webextensions"],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "auto_like",
+  "name": "Like_Instagram_posts",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "auto_like",
+      "name": "Like_Instagram_posts",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -14,8 +14,8 @@ const main = () => {
 window.addEventListener("scroll", (_) => {
   instagram.fetchLikeArticle(document).then((e) => {
     // todo fix
-    if (e.status === Response.SUCCESS && e.payload >= 1) {
-      snack.show(`${e.payload}投稿をいいねしました`, e.status);
+    if (e.status === Response.SUCCESS && e.payload !== "") {
+      snack.show(`${e.payload} を投稿をいいねしました`, e.status);
     }
   });
 });

--- a/src/content/content-script.ts
+++ b/src/content/content-script.ts
@@ -15,7 +15,7 @@ window.addEventListener("scroll", (_) => {
   instagram.fetchLikeArticle(document).then((e) => {
     // todo fix
     if (e.status === Response.SUCCESS && e.payload !== "") {
-      snack.show(`${e.payload} を投稿をいいねしました`, e.status);
+      snack.show(`${e.payload} の投稿をいいねしました`, e.status);
     }
   });
 });


### PR DESCRIPTION
## 概要

いままではタイムラインの dom が生成されている投稿に対してすべて送っていたが、制限に引っかかりやすいため、ウィンドウに表示されているもののみをいいねするようにした。

ウィンドウの領域に入っているかどうかは、投稿画像の高さが、ウィンドウの表示域に収まっているかにした。